### PR TITLE
task/search bar auto focus fix

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -70,6 +70,7 @@ export default function Search() {
           value={query}
           placeholder="Search..."
           className="search-input"
+          tabIndex={-1}
           onChange={(e) => setQuery(e.target.value)}
         />
         {open && (


### PR DESCRIPTION
added tabIndex attribute to search input so it doesnt auto-focus when opening mobile nav